### PR TITLE
Remove pub function 'is_timeout'

### DIFF
--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -69,29 +69,6 @@ impl<'a> CompletionQueueEvent<'a> {
     pub(crate) fn new(ring: NonNull<uring_sys::io_uring>, cqe: &'a mut uring_sys::io_uring_cqe) -> CompletionQueueEvent<'a> {
         CompletionQueueEvent { ring, cqe }
     }
-
-    /// Check whether this event is a timeout.
-    /// ```
-    /// # use iou::{IoUring, SubmissionQueueEvent};
-    /// # fn main() -> std::io::Result<()> {
-    /// # let mut ring = IoUring::new(2)?;
-    /// # let mut sqe = ring.next_sqe().unwrap();
-    /// #
-    /// # // make a fake timeout with a nop for testing
-    /// # unsafe { sqe.prep_nop(); }
-    /// # ring.submit_sqes()?;
-    /// #
-    /// # let mut cq_event;
-    /// cq_event = ring.wait_for_cqe()?;
-    /// # cq_event.raw_mut().user_data = uring_sys::LIBURING_UDATA_TIMEOUT;
-    /// assert!(cq_event.is_timeout());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn is_timeout(&self) -> bool {
-        self.cqe.user_data == uring_sys::LIBURING_UDATA_TIMEOUT
-    }
-
     pub fn user_data(&self) -> u64 {
         self.cqe.user_data as u64
     }


### PR DESCRIPTION
AFAIK, `LIBURING_UDATA_TIMEOUT` should only be used within internal library i.e. liburing, it is set to user_data by calls like `io_uring_wait_cqes`, and the correspond `cqe` handled by `__io_uring_peek_cqe`, so it should used by users in any situations.

According to `liburing/src/queue.c`:
> Applications using this function must never set sqe->user_data to LIBURING_UDATA_TIMEOUT!