### PR TITLE
Add RegisteredBuf API to manage registered buffers

### DIFF
--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -87,7 +87,7 @@ impl CQE {
 unsafe impl Send for CQE { }
 unsafe impl Sync for CQE { }
 
-/// An iterator of [`CQE`]s from the [`CompletionQueue`].
+/// An iterator of [`CQE`]s from the [`CompletionQueue`](crate::CompletionQueue).
 ///
 /// This iterator will be exhausted when there are no `CQE`s ready, and return `None`.
 pub struct CQEs<'a> {
@@ -137,7 +137,7 @@ impl Iterator for CQEs<'_> {
 }
 
 
-/// An iterator of [`CQE`]s from the [`CompletionQueue`].
+/// An iterator of [`CQE`]s from the [`CompletionQueue`](crate::CompletionQueue).
 ///
 /// This iterator will never be exhausted; if there are no `CQE`s ready, it will block until there
 /// are.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ mod submission_queue;
 
 mod probe;
 
-/// Types related to registration.
 pub mod registrar;
 
 use std::fmt;

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -9,7 +9,7 @@
 /// pre-registered resources. By passing a [`RegisteredFd`] or the correct type of registered
 /// buffer to an [`SQE`][crate::SQE]'s prep methods, the SQE will be properly prepared to use the
 /// pre-registered object.
-pub mod registered;
+mod registered;
 
 use std::fmt;
 use std::io;

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -72,7 +72,7 @@ impl<'ring> Registrar<'ring> {
         )
     }
 
-    pub fn register_buffers_by_ref<'a>(&self, buffers: &'a [io::IoSlice<'a>])
+    pub fn register_buffers_by_ref<'a>(&self, buffers: &'a [&'a [u8]])
         -> io::Result<impl Iterator<Item = RegisteredBufRef<'a>> + 'a>
     {
         let len = buffers.len();
@@ -87,7 +87,7 @@ impl<'ring> Registrar<'ring> {
         )
     }
 
-    pub fn register_buffers_by_mut<'a>(&self, buffers: &'a mut [io::IoSliceMut<'a>])
+    pub fn register_buffers_by_mut<'a>(&self, buffers: &'a mut [&'a mut [u8]])
         -> io::Result<impl Iterator<Item = RegisteredBufMut<'a>> + 'a>
     {
         let len = buffers.len();

--- a/src/registrar/registered.rs
+++ b/src/registrar/registered.rs
@@ -1,0 +1,262 @@
+use std::ops::*;
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use crate::SQE;
+
+pub const PLACEHOLDER_FD: RawFd = -1;
+
+/// A member of the kernel's registered fileset.
+///
+/// Valid `RegisteredFd`s can be obtained through a [`Registrar`](crate::registrar::Registrar).
+///
+/// Registered files handle kernel fileset indexing behind the scenes and can often be used in place
+/// of raw file descriptors. Not all IO operations support registered files.
+///
+/// Submission event prep methods on `RegisteredFd` will ensure that the submission event's
+/// `SubmissionFlags::FIXED_FILE` flag is properly set.
+pub type RegisteredFd           = Registered<RawFd>;
+pub type RegisteredBuf          = Registered<Box<[u8]>>;
+pub type RegisteredBufRef<'a>   = Registered<&'a [u8]>;
+pub type RegisteredBufMut<'a>   = Registered<&'a mut [u8]>;
+
+/// An object registered with an io-uring instance through a [`Registrar`](crate::Registrar).
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Registered<T> {
+    data: T,
+    index: u32,
+}
+
+impl<T> Registered<T> {
+    pub fn new(index: u32, data: T) -> Registered<T> {
+        Registered { data, index }
+    }
+
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+}
+
+impl RegisteredFd {
+    pub fn is_placeholder(&self) -> bool {
+        self.data == PLACEHOLDER_FD
+    }
+}
+
+impl AsRawFd for RegisteredFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.data
+    }
+}
+
+impl RegisteredBuf {
+    pub fn as_ref(&self) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[..])
+    }
+
+    pub fn as_mut(&mut self) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[..])
+    }
+
+    pub fn slice(&self, range: Range<usize>) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[range])
+    }
+
+    pub fn slice_mut(&mut self, range: Range<usize>) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[range])
+    }
+
+    pub fn slice_to(&self, index: usize) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[..index])
+    }
+
+    pub fn slice_to_mut(&mut self, index: usize) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[..index])
+    }
+
+    pub fn slice_from(&self, index: usize) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[index..])
+    }
+
+    pub fn slice_from_mut(&mut self, index: usize) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[index..])
+    }
+}
+
+impl<'a> RegisteredBufRef<'a> {
+    pub fn as_ref(&self) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[..])
+    }
+
+    pub fn slice(self, range: Range<usize>) -> RegisteredBufRef<'a> {
+        Registered::new(self.index, &self.data[range])
+    }
+
+    pub fn slice_to(&self, index: usize) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[..index])
+    }
+
+    pub fn slice_from(&self, index: usize) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[index..])
+    }
+}
+
+impl<'a> RegisteredBufMut<'a> {
+    pub fn as_ref(&self) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[..])
+    }
+
+    pub fn as_mut(&mut self) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[..])
+    }
+
+    pub fn slice(self, range: Range<usize>) -> RegisteredBufRef<'a> {
+        Registered::new(self.index, &self.data[range])
+    }
+
+    pub fn slice_mut(self, range: Range<usize>) -> RegisteredBufMut<'a> {
+        Registered::new(self.index, &mut self.data[range])
+    }
+
+    pub fn slice_to(&self, index: usize) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[..index])
+    }
+
+    pub fn slice_to_mut(&mut self, index: usize) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[..index])
+    }
+
+    pub fn slice_from(&self, index: usize) -> RegisteredBufRef<'_> {
+        Registered::new(self.index, &self.data[index..])
+    }
+
+    pub fn slice_from_mut(&mut self, index: usize) -> RegisteredBufMut<'_> {
+        Registered::new(self.index, &mut self.data[index..])
+    }
+}
+
+impl Deref for RegisteredBuf {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.data[..]
+    }
+}
+
+impl Deref for RegisteredBufRef<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.data[..]
+    }
+}
+
+impl Deref for RegisteredBufMut<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.data[..]
+    }
+}
+
+impl DerefMut for RegisteredBuf {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.data[..]
+    }
+}
+
+impl DerefMut for RegisteredBufMut<'_> {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.data[..]
+    }
+}
+/// A file descriptor that can be used to prepare SQEs.
+///
+/// The standard library's [`RawFd`] type implements this trait, but so does [`RegisteredFd`], a
+/// type which is returned when a user pre-registers file descriptors with an io-uring instance.
+pub trait UringFd {
+    fn as_raw_fd(&self) -> RawFd;
+    fn update_sqe(&self, sqe: &mut SQE<'_>);
+}
+
+impl UringFd for RawFd {
+    fn as_raw_fd(&self) -> RawFd {
+        *self
+    }
+
+    fn update_sqe(&self, _: &mut SQE<'_>) { }
+}
+
+impl UringFd for RegisteredFd {
+    fn as_raw_fd(&self) -> RawFd {
+        AsRawFd::as_raw_fd(self)
+    }
+
+    fn update_sqe(&self, sqe: &mut SQE<'_>) {
+        unsafe { sqe.raw_mut().fd = self.index as RawFd; }
+        sqe.set_fixed_file();
+    }
+}
+
+/// A buffer that can be used to prepare read events.
+pub trait UringReadBuf {
+    unsafe fn prep_read(self, fd: impl UringFd, sqe: &mut SQE<'_>, offset: u64);
+}
+
+/// A buffer that can be used to prepare write events.
+pub trait UringWriteBuf {
+    unsafe fn prep_write(self, fd: impl UringFd, sqe: &mut SQE<'_>, offset: u64);
+}
+
+impl UringReadBuf for RegisteredBufMut<'_> {
+    unsafe fn prep_read(self, fd: impl UringFd, sqe: &mut SQE<'_>, offset: u64) {
+        uring_sys::io_uring_prep_read_fixed(
+            sqe.raw_mut(),
+            fd.as_raw_fd(),
+            self.data.as_mut_ptr() as _,
+            self.data.len() as _,
+            offset as _,
+            self.index() as _
+        );
+        fd.update_sqe(sqe);
+    }
+}
+
+impl UringReadBuf for &'_ mut [u8] {
+    unsafe fn prep_read(self, fd: impl UringFd, sqe: &mut SQE<'_>, offset: u64) {
+        uring_sys::io_uring_prep_read(
+            sqe.raw_mut(),
+            fd.as_raw_fd(),
+            self.as_mut_ptr() as _,
+            self.len() as _,
+            offset as _,
+        );
+        fd.update_sqe(sqe);
+    }
+}
+
+impl UringWriteBuf for RegisteredBufRef<'_> {
+    unsafe fn prep_write(self, fd: impl UringFd, sqe: &mut SQE<'_>, offset: u64) {
+        uring_sys::io_uring_prep_write_fixed(
+            sqe.raw_mut(),
+            fd.as_raw_fd(),
+            self.data.as_ptr() as _,
+            self.data.len() as _,
+            offset as _,
+            self.index() as _
+        );
+        fd.update_sqe(sqe);
+    }
+}
+
+impl UringWriteBuf for &'_ [u8] {
+    unsafe fn prep_write(self, fd: impl UringFd, sqe: &mut SQE<'_>, offset: u64) {
+        uring_sys::io_uring_prep_write(
+            sqe.raw_mut(),
+            fd.as_raw_fd(),
+            self.as_ptr() as _,
+            self.len() as _,
+            offset as _,
+        );
+        fd.update_sqe(sqe);
+    }
+}

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{self, IoSliceMut};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 
 const TEXT: &[u8] = b"I really wanna stop
@@ -17,7 +17,7 @@ But I need to tell you something
 I really really really really really really like you";
 
 #[test]
-fn read_test() -> io::Result<()> {
+fn vectored_read_test() -> io::Result<()> {
     let mut io_uring = iou::IoUring::new(32)?;
 
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -25,10 +25,14 @@ fn read_test() -> io::Result<()> {
     path.push("text.txt");
     let file = File::open(&path)?;
     let mut buf1 = [0; 4096];
-    let mut bufs = [io::IoSliceMut::new(&mut buf1)];
+    let mut bufs = [IoSliceMut::new(&mut buf1)];
 
     unsafe {
-        prep(&mut io_uring, &mut bufs, file.as_raw_fd())?;
+        let mut sq = io_uring.sq();
+        let mut sqe = sq.prepare_sqe().unwrap();
+        sqe.prep_read_vectored(file.as_raw_fd(), &mut bufs[..], 0);
+        sqe.set_user_data(0xDEADBEEF);
+        sq.submit()?;
     }
 
     let n = {
@@ -42,12 +46,62 @@ fn read_test() -> io::Result<()> {
     Ok(())
 }
 
-#[inline(never)]
-unsafe fn prep(ring: &mut iou::IoUring, bufs: &mut [IoSliceMut], fd: RawFd) -> io::Result<()> {
-    let mut sq = ring.sq();
-    let mut sqe = sq.prepare_sqe().unwrap();
-    sqe.prep_read_vectored(fd, bufs, 0);
-    sqe.set_user_data(0xDEADBEEF);
-    sq.submit()?;
+#[test]
+fn read_test() -> io::Result<()> {
+    let mut io_uring = iou::IoUring::new(32)?;
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("props");
+    path.push("text.txt");
+    let file = File::open(&path)?;
+    let mut buf = [0; 4096];
+
+    unsafe {
+        let mut sq = io_uring.sq();
+        let mut sqe = sq.prepare_sqe().unwrap();
+        sqe.prep_read(file.as_raw_fd(), &mut buf[..], 0);
+        sqe.set_user_data(0xDEADBEEF);
+        sq.submit()?;
+    }
+
+    let n = {
+        let mut cq = io_uring.cq();
+        let cqe = cq.wait_for_cqe()?;
+        assert_eq!(cqe.user_data(), 0xDEADBEEF);
+        cqe.result()? as usize
+    };
+
+    assert_eq!(&TEXT[..n], &buf[..n]);
+    Ok(())
+}
+
+#[test]
+fn read_registered_buf() -> io::Result<()> {
+    let mut io_uring = iou::IoUring::new(32)?;
+    let bufs = vec![Box::new([0u8; 4096]) as Box<[u8]>];
+    let mut buf: iou::registrar::RegisteredBuf = io_uring.registrar().register_buffers(bufs)?.next().unwrap();
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("props");
+    path.push("text.txt");
+    let file = File::open(&path)?;
+
+    unsafe {
+        let mut sq = io_uring.sq();
+        let mut sqe = sq.prepare_sqe().unwrap();
+        sqe.prep_read(file.as_raw_fd(), buf.as_mut(), 0);
+        sqe.set_user_data(0xDEADBEEF);
+        assert!(sqe.raw().opcode == uring_sys::IoRingOp::IORING_OP_READ_FIXED as u8);
+        sq.submit()?;
+    }
+
+    let n = {
+        let mut cq = io_uring.cq();
+        let cqe = cq.wait_for_cqe()?;
+        assert_eq!(cqe.user_data(), 0xDEADBEEF);
+        cqe.result()? as usize
+    };
+
+    assert_eq!(&TEXT[..n], &buf.slice_to(n)[..]);
     Ok(())
 }

--- a/tests/register-buffers.rs
+++ b/tests/register-buffers.rs
@@ -1,0 +1,40 @@
+#[test]
+fn register_buffers_by_val() {
+    let buf1 = vec![0; 1024].into_boxed_slice();
+    let buf2 = vec![0; 1024].into_boxed_slice();
+    let ring = iou::IoUring::new(8).unwrap();
+    let bufs: Vec<_> = ring.registrar()
+                           .register_buffers(vec![buf1, buf2])
+                           .unwrap().collect();
+    assert_eq!(bufs.len(), 2);
+    assert_eq!(bufs[0].index(), 0);
+    assert_eq!(bufs[1].index(), 1);
+}
+
+#[test]
+fn register_buffers_by_ref() {
+    let buf1 = vec![0; 1024];
+    let buf2 = vec![0; 1024];
+    let ring = iou::IoUring::new(8).unwrap();
+    let bufs = &[&buf1[..], &buf2[..]];
+    let bufs: Vec<_> = ring.registrar()
+                           .register_buffers_by_ref(bufs)
+                           .unwrap().collect();
+    assert_eq!(bufs.len(), 2);
+    assert_eq!(bufs[0].index(), 0);
+    assert_eq!(bufs[1].index(), 1);
+}
+
+#[test]
+fn register_buffers_by_mut() {
+    let mut buf1 = vec![0; 1024];
+    let mut buf2 = vec![0; 1024];
+    let ring = iou::IoUring::new(8).unwrap();
+    let bufs = &mut [&mut buf1[..], &mut buf2[..]];
+    let bufs: Vec<_> = ring.registrar()
+                           .register_buffers_by_mut(bufs)
+                           .unwrap().collect();
+    assert_eq!(bufs.len(), 2);
+    assert_eq!(bufs[0].index(), 0);
+    assert_eq!(bufs[1].index(), 1);
+}

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -110,6 +110,7 @@ fn write_registered_buf() -> io::Result<()> {
             let mut sq = io_uring.sq();
             let mut sqe = sq.prepare_sqe().unwrap();
             sqe.prep_write(file.as_raw_fd(), buf.slice_to(TEXT.len()), 0);
+            assert!(sqe.raw().opcode == uring_sys::IoRingOp::IORING_OP_WRITE_FIXED as u8);
             sqe.set_user_data(0xDEADBEEF);
             io_uring.sq().submit()?;
         }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -17,10 +17,10 @@ But I need to tell you something
 I really really really really really really like you";
 
 #[test]
-fn write_test() -> io::Result<()> {
+fn vectored_write_test() -> io::Result<()> {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("props");
-    path.push("text.tmp");
+    path.push("vectored.tmp");
 
     let _ = fs::remove_file(&path);
     
@@ -54,3 +54,77 @@ fn write_test() -> io::Result<()> {
     Ok(())
 }
 
+#[test]
+fn write_test() -> io::Result<()> {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("props");
+    path.push("text.tmp");
+
+    let _ = fs::remove_file(&path);
+    
+    let n = {
+        let mut io_uring = iou::IoUring::new(32)?;
+
+        let file = File::create(&path)?;
+        unsafe {
+            let mut sq = io_uring.sq();
+            let mut sqe = sq.prepare_sqe().unwrap();
+            sqe.prep_write(file.as_raw_fd(), TEXT, 0);
+            sqe.set_user_data(0xDEADBEEF);
+            io_uring.sq().submit()?;
+        }
+
+        let mut cq = io_uring.cq();
+        let cqe = cq.wait_for_cqe()?;
+        assert_eq!(cqe.user_data(), 0xDEADBEEF);
+        cqe.result()? as usize
+    };
+
+    let mut file = File::open(&path)?;
+    let mut buf = vec![];
+    file.read_to_end(&mut buf)?;
+    assert_eq!(&TEXT[..n], &buf[..n]);
+    let _ = fs::remove_file(&path);
+
+    Ok(())
+}
+
+
+#[test]
+fn write_registered_buf() -> io::Result<()> {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("props");
+    path.push("write_registered_buf.tmp");
+
+    let _ = fs::remove_file(&path);
+
+    let mut io_uring = iou::IoUring::new(32)?;
+    let bufs = vec![Box::new([0u8; 4096]) as Box<[u8]>];
+    let mut buf: iou::registrar::RegisteredBuf = io_uring.registrar().register_buffers(bufs)?.next().unwrap();
+
+    buf.as_mut().slice_to_mut(TEXT.len()).copy_from_slice(TEXT);
+
+    let n = {
+        let file = File::create(&path)?;
+        unsafe {
+            let mut sq = io_uring.sq();
+            let mut sqe = sq.prepare_sqe().unwrap();
+            sqe.prep_write(file.as_raw_fd(), buf.slice_to(TEXT.len()), 0);
+            sqe.set_user_data(0xDEADBEEF);
+            io_uring.sq().submit()?;
+        }
+
+        let mut cq = io_uring.cq();
+        let cqe = cq.wait_for_cqe()?;
+        assert_eq!(cqe.user_data(), 0xDEADBEEF);
+        cqe.result()? as usize
+    };
+
+    let mut file = File::open(&path)?;
+    let mut buf = vec![];
+    file.read_to_end(&mut buf)?;
+    assert_eq!(&TEXT[..n], &buf[..n]);
+    let _ = fs::remove_file(&path);
+
+    Ok(())
+}


### PR DESCRIPTION
cc @mxxo 

Generalizes `RegisteredFd` to also support `RegisteredBuf` with a similar strategy. Now, users can pre-register both FDs and buffers and pass either to `prep_read` and `prep_write` to get a correctly prepared IO event.