### PR TITLE
Implement Debug for CQE

### DIFF
--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -6,6 +6,7 @@ use std::ptr::{self, NonNull};
 use super::{IoUring, resultify};
 
 /// A completed IO event.
+#[derive(Debug)]
 pub struct CQE {
     user_data: u64,
     res: i32,


### PR DESCRIPTION
Makes `CQE` implement `std::fmt::Debug`. At the moment it's simply a #[derive(Debug)], but the existence of the
impl is more important than how it's printed, at least initially.