### PR TITLE
use is_null method for pointer checks (clippy lint)

### DIFF
--- a/src/completion_queue.rs
+++ b/src/completion_queue.rs
@@ -30,7 +30,7 @@ impl<'ring> CompletionQueue<'ring> {
             let mut cqe = MaybeUninit::uninit();
             uring_sys::io_uring_peek_cqe(self.ring.as_ptr(), cqe.as_mut_ptr());
             let cqe = cqe.assume_init();
-            if cqe != ptr::null_mut() {
+            if !cqe.is_null() {
                 Some(CQE::new(self.ring, &mut *cqe))
             } else {
                 None

--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -89,7 +89,7 @@ impl<'a> CQEs<'a> {
             let mut cqe = MaybeUninit::uninit();
             uring_sys::io_uring_peek_cqe(self.ring.as_ptr(), cqe.as_mut_ptr());
             let cqe = cqe.assume_init();
-            if cqe != ptr::null_mut() {
+            if !cqe.is_null() {
                 Some(CQE::new(self.ring, &mut *cqe))
             } else {
                 None
@@ -142,7 +142,7 @@ impl<'a> CQEsBlocking<'a> {
             let mut cqe = MaybeUninit::uninit();
             uring_sys::io_uring_peek_cqe(self.ring.as_ptr(), cqe.as_mut_ptr());
             let cqe = cqe.assume_init();
-            if cqe != ptr::null_mut() {
+            if !cqe.is_null() {
                 Some(CQE::new(self.ring, &mut *cqe))
             } else {
                 None

--- a/src/submission_queue.rs
+++ b/src/submission_queue.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::io;
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 use std::marker::PhantomData;
 use std::slice;
 use std::time::Duration;
@@ -143,7 +143,7 @@ unsafe impl<'ring> Sync for SubmissionQueue<'ring> { }
 
 pub(crate) unsafe fn prepare_sqe<'a>(ring: &mut uring_sys::io_uring) -> Option<SQE<'a>> {
     let sqe = uring_sys::io_uring_get_sqe(ring);
-    if sqe != ptr::null_mut() {
+    if !sqe.is_null() {
         let mut sqe = SQE::new(&mut *sqe);
         sqe.clear();
         Some(sqe)


### PR DESCRIPTION
I did a clippy run and it suggested switching to `ptr.is_null()` which lets us avoid the possible temporary pointer. 