### PR TITLE
add a debug implementation for SockAddrStorage

### DIFF
--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -523,6 +523,7 @@ impl<'a> SQE<'a> {
 unsafe impl<'a> Send for SQE<'a> { }
 unsafe impl<'a> Sync for SQE<'a> { }
 
+#[derive(Debug)]
 pub struct SockAddrStorage {
     storage: mem::MaybeUninit<nix::sys::socket::sockaddr_storage>,
     len: usize,


### PR DESCRIPTION
This structure is likely to be embedded in other structure so it
has a stable address. Having a debug implementation helps so that
the users can simply #[derive(Debug)]